### PR TITLE
Resolve 'start' issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-keyframes",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A module for extract keyframes from video files with FFMPEG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There existed a condition where if a small media file was being processed the `start` event would be fired before the application logic could bind an event listener to it.

This fix introduces an artificial delay of *100ms* to allow application logic plenty of time to bind listeners to the events exposed